### PR TITLE
fix: allowing schema refs to not start with `#/definitions`

### DIFF
--- a/packages/core/src/utils.js
+++ b/packages/core/src/utils.js
@@ -539,7 +539,7 @@ export function optionsList(schema) {
 
 function findSchemaDefinition($ref, definitions = {}) {
   // Extract and use the referenced definition if we have it.
-  const match = /^#\/definitions\/(.*)$/.exec($ref);
+  const match = /^#(?:\/definitions)?\/(.*)$/.exec($ref);
   if (match && match[1]) {
     const parts = match[1].split("/");
     let current = definitions;


### PR DESCRIPTION
Allow schema definitions to not have to start with `#/definitions`.

Originally fixed in #954, but a new solution has been done in #1506. Backporting our original fix into this fork so we can maintain it while running on a later version of RJSF.