### PR TITLE
style: remove ecmaFeatures from eslintrc

### DIFF
--- a/packages/core/.eslintrc
+++ b/packages/core/.eslintrc
@@ -26,11 +26,6 @@
         "node": true
     },
     "extends": "eslint:recommended",
-    "ecmaFeatures": {
-        "modules": true,
-        "jsx": true,
-        "experimentalObjectRestSpread": true
-    },
     "plugins": [
         "jsx-a11y",
         "react"


### PR DESCRIPTION
Having this in `eslintrc` right now is preventing releases from being able to be packaged up.