### PR TITLE
feat: adding support for overriding UnsupportedField

### DIFF
--- a/packages/core/src/components/fields/ArrayField.js
+++ b/packages/core/src/components/fields/ArrayField.js
@@ -4,7 +4,6 @@ import React, { Component } from "react";
 import includes from "core-js/library/fn/array/includes";
 import * as types from "../../types";
 
-import UnsupportedField from "./UnsupportedField";
 import {
   getWidget,
   getDefaultFormState,
@@ -427,6 +426,9 @@ class ArrayField extends Component {
     } = this.props;
     const { rootSchema } = registry;
     if (!schema.hasOwnProperty("items")) {
+      const { fields } = registry;
+      const { UnsupportedField } = fields;
+
       return (
         <UnsupportedField
           schema={schema}

--- a/packages/core/src/components/fields/SchemaField.js
+++ b/packages/core/src/components/fields/SchemaField.js
@@ -16,7 +16,6 @@ import {
   deepEquals,
   getSchemaType,
 } from "../../utils";
-import UnsupportedField from "./UnsupportedField";
 
 const REQUIRED_FIELD_SYMBOL = "*";
 const COMPONENT_TYPES = {
@@ -29,7 +28,7 @@ const COMPONENT_TYPES = {
   null: "NullField",
 };
 
-function getFieldComponent(schema, uiSchema, idSchema, fields) {
+function getFieldComponent(schema, uiSchema, idSchema, fields, registry) {
   const field = uiSchema["ui:field"];
   if (typeof field === "function") {
     return field;
@@ -49,6 +48,9 @@ function getFieldComponent(schema, uiSchema, idSchema, fields) {
   return componentName in fields
     ? fields[componentName]
     : () => {
+        const { fields } = registry;
+        const { UnsupportedField } = fields;
+
         return (
           <UnsupportedField
             schema={schema}
@@ -246,7 +248,13 @@ function SchemaFieldRender(props) {
     toIdSchema(schema, null, rootSchema, formData, idPrefix),
     idSchema
   );
-  const FieldComponent = getFieldComponent(schema, uiSchema, idSchema, fields);
+  const FieldComponent = getFieldComponent(
+    schema,
+    uiSchema,
+    idSchema,
+    fields,
+    registry
+  );
   const { DescriptionField } = fields;
   const disabled = Boolean(props.disabled || uiSchema["ui:disabled"]);
   const readonly = Boolean(

--- a/packages/core/test/ArrayField_test.js
+++ b/packages/core/test/ArrayField_test.js
@@ -84,6 +84,22 @@ describe("ArrayField", () => {
         node.querySelector(".field-array > .unsupported-field").textContent
       ).to.contain("Missing items definition");
     });
+
+    it("should be able to be overwritten with a custom UnsupportedField component", () => {
+      const CustomUnsupportedField = function() {
+        return <span id="custom">Custom UnsupportedField</span>;
+      };
+
+      const fields = { UnsupportedField: CustomUnsupportedField };
+      const { node } = createFormComponent({
+        schema: { type: "array" },
+        fields,
+      });
+
+      expect(node.querySelectorAll("#custom")[0].textContent).to.eql(
+        "Custom UnsupportedField"
+      );
+    });
   });
 
   describe("List of inputs", () => {

--- a/packages/core/test/SchemaField_test.js
+++ b/packages/core/test/SchemaField_test.js
@@ -90,6 +90,22 @@ describe("SchemaField", () => {
         "Unknown field type invalid"
       );
     });
+
+    it("should be able to be overwritten with a custom UnsupportedField component", () => {
+      const CustomUnsupportedField = function() {
+        return <span id="custom">Custom UnsupportedField</span>;
+      };
+
+      const fields = { UnsupportedField: CustomUnsupportedField };
+      const { node } = createFormComponent({
+        schema: { type: "invalid" },
+        fields,
+      });
+
+      expect(node.querySelectorAll("#custom")[0].textContent).to.eql(
+        "Custom UnsupportedField"
+      );
+    });
   });
 
   describe("Custom SchemaField component", () => {


### PR DESCRIPTION
We need to be able to allow `UnsupportedField` to throw an actual `Error` so we can capture it and can't do this without supplying a custom `UnsupportedField` component.