### PR TITLE
fix: adding support for handling empty array `items` declarations

### DIFF
--- a/packages/core/src/components/fields/ArrayField.js
+++ b/packages/core/src/components/fields/ArrayField.js
@@ -712,13 +712,13 @@ class ArrayField extends Component {
   }
 
   renderArrayFieldItem(props) {
+    let { itemSchema } = props;
     const {
       key,
       index,
       canRemove = true,
       canMoveUp = true,
       canMoveDown = true,
-      itemSchema,
       itemData,
       itemUiSchema,
       itemIdSchema,
@@ -748,6 +748,18 @@ class ArrayField extends Component {
       remove: removable && canRemove,
     };
     has.toolbar = Object.keys(has).some(key => has[key]);
+
+    // If we have an array with either an empty `items` declaration (eg. `items: {}`), we should be able to handle
+    // that as just a standard mixed type input.
+    if (
+      typeof itemSchema === "object" &&
+      itemSchema !== null &&
+      Object.keys(itemSchema).length === 0
+    ) {
+      itemSchema = {
+        type: "string",
+      };
+    }
 
     return {
       children: (

--- a/packages/core/test/ArrayField_test.js
+++ b/packages/core/test/ArrayField_test.js
@@ -237,6 +237,21 @@ describe("ArrayField", () => {
       expect(node.querySelectorAll(".field-string")).to.have.length.of(1);
     });
 
+    it("should add a new field when clicking the add button and the array has an empty `items` declaration", () => {
+      const { node } = createFormComponent({
+        schema: {
+          type: "array",
+          title: "my list",
+          description: "my description",
+          items: {},
+        },
+      });
+
+      Simulate.click(node.querySelector(".array-item-add button"));
+
+      expect(node.querySelectorAll(".field-string")).to.have.length.of(1);
+    });
+
     it("should assign new keys/ids when clicking the add button", () => {
       const { node } = createFormComponent({
         schema,


### PR DESCRIPTION
### Reasons for making this change

This resolves a bug where if an array were defined as `{type: "array", items: {}}`, the form module would fail to render because it was attempting to render an undefined schema type. 

Per the OAS spec, `items: {}` means a mixed type input for the parent array, so as there's no "mixed" format, we're defaulting to rendering standard `string` inputs for these arrays.

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
