### PR TITLE
fix: adding a custom jsonschema allof resolver for `format`

### DIFF
--- a/packages/core/src/utils.js
+++ b/packages/core/src/utils.js
@@ -657,10 +657,20 @@ export function retrieveSchema(schema, rootSchema = {}, formData = {}) {
   let resolvedSchema = resolveSchema(schema, rootSchema, formData);
   if ("allOf" in schema) {
     try {
-      resolvedSchema = mergeAllOf({
-        ...resolvedSchema,
-        allOf: resolvedSchema.allOf,
-      });
+      resolvedSchema = mergeAllOf(
+        {
+          ...resolvedSchema,
+          allOf: resolvedSchema.allOf,
+        },
+        {
+          // JSON Schema has no support for `format` on anything other than `string`, but since OpenAPI has it on
+          // `integer` and `number`, we need to add a custom resolver here so we can still merge schemas that may
+          // have those!
+          resolvers: {
+            format: obj => obj[0],
+          },
+        }
+      );
     } catch (e) {
       console.warn("could not merge subschemas in allOf:\n" + e);
       const { allOf, ...resolvedSchemaWithoutAllOf } = resolvedSchema;

--- a/packages/core/test/utils_test.js
+++ b/packages/core/test/utils_test.js
@@ -2382,6 +2382,26 @@ describe("utils", () => {
           default: "hi",
         });
       });
+
+      it("should properly merge schemas with a `format` property on an integer or number", () => {
+        const schema = {
+          allOf: [
+            {
+              type: "integer",
+              format: "int32",
+            },
+            {
+              type: "integer",
+            },
+          ],
+        };
+        const definitions = {};
+        const formData = {};
+        expect(retrieveSchema(schema, { definitions }, formData)).eql({
+          type: "integer",
+          format: "int32",
+        });
+      });
     });
   });
 


### PR DESCRIPTION
### Reasons for making this change

This resolves a bug with merging `allOf` schemas that have a `format` where `json-schema-merge-allof` doesn't have a resolver set up for it so RJSF would dump the contents of the schema, which would then cascase up to a complete failure to render the item because `format` was empty.

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
