### PR TITLE
fix: if an allOf schema has an `example`, carry it through

### DIFF
--- a/packages/core/src/utils.js
+++ b/packages/core/src/utils.js
@@ -663,10 +663,14 @@ export function retrieveSchema(schema, rootSchema = {}, formData = {}) {
           allOf: resolvedSchema.allOf,
         },
         {
-          // JSON Schema has no support for `format` on anything other than `string`, but since OpenAPI has it on
-          // `integer` and `number`, we need to add a custom resolver here so we can still merge schemas that may
-          // have those!
           resolvers: {
+            // JSON Schema's support for examples is relegated to the `examples` property. If we have this instead, let
+            // it be!
+            example: obj => obj[0],
+
+            // JSON Schema has no support for `format` on anything other than `string`, but since OpenAPI has it on
+            // `integer` and `number`, we need to add a custom resolver here so we can still merge schemas that may
+            // have those!
             format: obj => obj[0],
           },
         }

--- a/packages/core/test/utils_test.js
+++ b/packages/core/test/utils_test.js
@@ -2383,6 +2383,27 @@ describe("utils", () => {
         });
       });
 
+      it("should properly merge schemas with a `example` property", () => {
+        const schema = {
+          allOf: [
+            {
+              type: "object",
+            },
+          ],
+          example: {
+            tktk: "tktk",
+          },
+        };
+        const definitions = {};
+        const formData = {};
+        expect(retrieveSchema(schema, { definitions }, formData)).eql({
+          example: {
+            tktk: "tktk",
+          },
+          type: "object",
+        });
+      });
+
       it("should properly merge schemas with a `format` property on an integer or number", () => {
         const schema = {
           allOf: [


### PR DESCRIPTION
### Reasons for making this change

If an `allOf` schema has an `example` property as per the OpenAPI spec (not JSON Schema), carry it through instead of letting `json-schema-merge-allof` fail on it.

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
