### PR TITLE
fix: be able to omit checking for array definitions

### DIFF
--- a/packages/core/src/components/fields/SchemaField.js
+++ b/packages/core/src/components/fields/SchemaField.js
@@ -241,7 +241,7 @@ function SchemaFieldRender(props) {
     wasPropertyKeyModified = false,
   } = props;
   const { rootSchema, fields, formContext } = registry;
-  if (isCyclic(props.schema, rootSchema)) {
+  if (isCyclic(props.schema, rootSchema, { array: false })) {
     return null;
   }
 

--- a/packages/core/src/components/fields/SchemaField.js
+++ b/packages/core/src/components/fields/SchemaField.js
@@ -7,7 +7,6 @@ import * as types from "../../types";
 import {
   isMultiSelect,
   isSelect,
-  isCyclic,
   retrieveSchema,
   toIdSchema,
   getDefaultRegistry,
@@ -241,9 +240,6 @@ function SchemaFieldRender(props) {
     wasPropertyKeyModified = false,
   } = props;
   const { rootSchema, fields, formContext } = registry;
-  if (isCyclic(props.schema, rootSchema, { array: false })) {
-    return null;
-  }
 
   const FieldTemplate =
     uiSchema["ui:FieldTemplate"] || registry.FieldTemplate || DefaultTemplate;

--- a/packages/core/src/components/fields/SchemaField.js
+++ b/packages/core/src/components/fields/SchemaField.js
@@ -7,6 +7,7 @@ import * as types from "../../types";
 import {
   isMultiSelect,
   isSelect,
+  isCyclic,
   retrieveSchema,
   toIdSchema,
   getDefaultRegistry,
@@ -240,6 +241,9 @@ function SchemaFieldRender(props) {
     wasPropertyKeyModified = false,
   } = props;
   const { rootSchema, fields, formContext } = registry;
+  if (isCyclic(props.schema, rootSchema, { array: false })) {
+    return null;
+  }
 
   const FieldTemplate =
     uiSchema["ui:FieldTemplate"] || registry.FieldTemplate || DefaultTemplate;

--- a/packages/core/src/utils.js
+++ b/packages/core/src/utils.js
@@ -104,7 +104,9 @@ export function isCyclic(schema, rootSchema, options = { array: true }) {
    */
   const checkChildren = children => {
     return children.reduce((acc, child) => {
-      return Boolean(check(child) | acc);
+      const result = Boolean(check(child) | acc);
+      traversed.delete(child);
+      return result;
     }, false);
   };
 

--- a/packages/core/src/utils.js
+++ b/packages/core/src/utils.js
@@ -255,7 +255,7 @@ function computeDefaults(
     // Use referenced schema defaults for this node.
     const refSchema = findSchemaDefinition(schema.$ref, rootSchema);
 
-    if (isCyclic(schema, rootSchema, { array: false })) {
+    if (isCyclic(schema, rootSchema)) {
       return undefined;
     }
 
@@ -1056,7 +1056,7 @@ export function toIdSchema(
     $id: id || idPrefix,
   };
 
-  if (isCyclic(schema, rootSchema, { array: false })) {
+  if (isCyclic(schema, rootSchema)) {
     return idSchema;
   }
 

--- a/packages/core/src/utils.js
+++ b/packages/core/src/utils.js
@@ -94,7 +94,7 @@ export function getSchemaType(schema) {
 }
 
 // detects whether a schema references itself recursively
-export function isCyclic(schema, rootSchema) {
+export function isCyclic(schema, rootSchema, options = { array: true }) {
   const traversed = new Set();
 
   /**
@@ -146,6 +146,9 @@ export function isCyclic(schema, rootSchema) {
         return result;
       }
       case "array": {
+        if (!options.array) {
+          return false; // we don't want to be proactive about checking for definitions in arrays
+        }
         if (Array.isArray(schema.items)) {
           const result = checkChildren(schema.items);
           traversed.delete(schema);
@@ -252,7 +255,7 @@ function computeDefaults(
     // Use referenced schema defaults for this node.
     const refSchema = findSchemaDefinition(schema.$ref, rootSchema);
 
-    if (isCyclic(schema, rootSchema)) {
+    if (isCyclic(schema, rootSchema, { array: false })) {
       return undefined;
     }
 
@@ -1053,7 +1056,7 @@ export function toIdSchema(
     $id: id || idPrefix,
   };
 
-  if (isCyclic(schema, rootSchema)) {
+  if (isCyclic(schema, rootSchema, { array: false })) {
     return idSchema;
   }
 

--- a/packages/core/test/utils_test.js
+++ b/packages/core/test/utils_test.js
@@ -3675,7 +3675,7 @@ describe("Utils.isCyclic", () => {
       },
     };
     schema.properties.foo.properties.foo = schema.properties.foo;
-    const result = isCyclic(schema.properties.foo, undefined, schema);
+    const result = isCyclic(schema.properties.foo, undefined);
     expect(result).eql(true);
   });
 
@@ -3760,6 +3760,40 @@ describe("Utils.isCyclic", () => {
     };
     const result = isCyclic(schema, schema);
     expect(result).eql(true);
+  });
+
+  it("should add an option for omitting running for arrays", () => {
+    const schema = {
+      type: "object",
+      definitions: {
+        tree: {
+          $ref: "#/definitions/branch",
+        },
+        branch: {
+          type: "object",
+          properties: {
+            leaves: {
+              $ref: "#/definitions/seed",
+            },
+          },
+        },
+        seed: {
+          type: "array",
+          items: [
+            {
+              $ref: "#/definitions/tree",
+            },
+          ],
+        },
+      },
+      properties: {
+        myTree: {
+          $ref: "#/definitions/tree",
+        },
+      },
+    };
+    const result = isCyclic(schema, schema, { array: false });
+    expect(result).eql(false);
   });
 
   it("should check type array where array = {}", () => {

--- a/packages/core/test/utils_test.js
+++ b/packages/core/test/utils_test.js
@@ -3796,6 +3796,60 @@ describe("Utils.isCyclic", () => {
     expect(result).eql(false);
   });
 
+  it("should pass on a schema that is cyclical, but not in a way that will recurse against itself", () => {
+    const schema = {
+      type: "object",
+      properties: {
+        dateTime: { type: "string", format: "date-time" },
+        offsetAfter: { $ref: "#/definitions/offset" },
+        offsetBefore: { $ref: "#/definitions/offset" },
+      },
+    };
+
+    const rootSchema = {
+      definitions: {
+        offset: {
+          type: "object",
+          properties: {
+            id: { type: "string" },
+            rules: { $ref: "#/definitions/rules" },
+          },
+        },
+        offsetTransition: {
+          type: "object",
+          properties: {
+            dateTime: { type: "string", format: "date-time" },
+            offsetAfter: { $ref: "#/definitions/offset" },
+            offsetBefore: { $ref: "#/definitions/offset" },
+          },
+        },
+        rules: {
+          type: "object",
+          properties: {
+            transitions: {
+              type: "array",
+              items: { $ref: "#/definitions/offsetTransition" },
+            },
+          },
+        },
+      },
+      properties: {
+        rules: {
+          type: "object",
+          properties: {
+            transitions: {
+              type: "array",
+              items: { $ref: "#/definitions/offsetTransition" },
+            },
+          },
+        },
+      },
+    };
+
+    const result = isCyclic(schema, rootSchema, { array: false });
+    expect(result).eql(false);
+  });
+
   it("should check type array where array = {}", () => {
     const schema = {
       type: "object",


### PR DESCRIPTION
### Reasons for making this change

- We need to be able to cut off the function from being overtly proactive about detecting whether it is cyclical or not.
- We need to check within arrays within the initialization step, but not at the component render step because the component-render step will not render anything within arrays unless the user adds an array item.

If this is related to existing tickets, include links to them as well.

Related to:
- https://github.com/readmeio/api-explorer/pull/852
- https://github.com/readmeio/react-jsonschema-form/pull/14

### How to test:

Chuck this into the playground and ensure that it does not trigger the maximum callstack error.
```
{
  "definitions": {
    "node": {
      "type": "object",
      "properties": {
        "name": {
          "type": "string"
        },
        "children": {
          "type": "array",
          "items": {
            "$ref": "#/definitions/node"
          }
        },
        "otherNode": {
          "$ref": "#/definitions/node"
        }
      }
    }
  },
  "type": "object",
  "properties": {
    "tree": {
      "title": "Recursive references",
      "$ref": "#/definitions/node"
    }
  }
}
```

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
