### PR TITLE
fix: comment out problematic polymorphic handling

### DIFF
--- a/packages/core/src/components/fields/MultiSchemaField.js
+++ b/packages/core/src/components/fields/MultiSchemaField.js
@@ -8,7 +8,7 @@ import {
   retrieveSchema,
   getDefaultFormState,
   getMatchingOption,
-  deepEquals,
+  // deepEquals,
 } from "../../utils";
 
 class AnyOfField extends Component {
@@ -22,7 +22,7 @@ class AnyOfField extends Component {
     };
   }
 
-  componentDidUpdate(prevProps, prevState) {
+  /* componentDidUpdate(prevProps, prevState) {
     if (
       !deepEquals(this.props.formData, prevProps.formData) &&
       this.props.idSchema.$id === prevProps.idSchema.$id
@@ -40,7 +40,7 @@ class AnyOfField extends Component {
         selectedOption: matchingOption,
       });
     }
-  }
+  } */
 
   getMatchingOption(formData, options) {
     const { rootSchema } = this.props.registry;

--- a/packages/core/test/anyOf_test.js
+++ b/packages/core/test/anyOf_test.js
@@ -3,7 +3,10 @@ import { expect } from "chai";
 import { Simulate } from "react-dom/test-utils";
 import sinon from "sinon";
 
-import { createFormComponent, createSandbox, setProps } from "./test_utils";
+import {
+  createFormComponent,
+  createSandbox /* setProps */,
+} from "./test_utils";
 
 describe("anyOf", () => {
   let sandbox;
@@ -377,7 +380,7 @@ describe("anyOf", () => {
     expect(node.querySelector("select").value).eql("1");
   });
 
-  it("should select the correct field when the formData property is updated", () => {
+  /* it("should select the correct field when the formData property is updated", () => {
     const schema = {
       type: "object",
       properties: {
@@ -408,7 +411,7 @@ describe("anyOf", () => {
     });
 
     expect(node.querySelector("select").value).eql("1");
-  });
+  }); */
 
   it("should not change the selected option when entering values", () => {
     const schema = {

--- a/packages/core/test/oneOf_test.js
+++ b/packages/core/test/oneOf_test.js
@@ -3,7 +3,10 @@ import { expect } from "chai";
 import { Simulate } from "react-dom/test-utils";
 import sinon from "sinon";
 
-import { createFormComponent, createSandbox, setProps } from "./test_utils";
+import {
+  createFormComponent,
+  createSandbox /* setProps */,
+} from "./test_utils";
 
 describe("oneOf", () => {
   let sandbox;
@@ -383,7 +386,7 @@ describe("oneOf", () => {
     expect(node.querySelector("select").value).eql("1");
   });
 
-  it("should select the correct field when the formData property is updated", () => {
+  /* it("should select the correct field when the formData property is updated", () => {
     const schema = {
       type: "object",
       properties: {
@@ -414,7 +417,7 @@ describe("oneOf", () => {
     });
 
     expect(node.querySelector("select").value).eql("1");
-  });
+  }); */
 
   it("should not change the selected option when entering values on a subschema with multiple required options", () => {
     const schema = {


### PR DESCRIPTION
### Reasons for making this change

With a complex `oneOf` schema, editing data within the form will adhoc change the selected input, resulting in complete state loss for the user.

[See this in action in the RJSF playground.](https://rjsf-team.github.io/react-jsonschema-form/#eyJmb3JtRGF0YSI6eyJyZWdpc3RyYXRpb24iOnt9LCJleGVtcHRpb24iOnt9fSwic2NoZW1hIjp7InR5cGUiOiJvYmplY3QiLCJvbmVPZiI6W3sidGl0bGUiOiJBbmRhbHVjaWEiLCJ0eXBlIjoib2JqZWN0IiwicHJvcGVydGllcyI6eyJsaXN0aW5nX2lkIjp7InR5cGUiOiJpbnRlZ2VyIn0sInJlZ3VsYXRvcnlfYm9keSI6eyJ0eXBlIjoic3RyaW5nIn0sInJlZ2lzdHJhdGlvbiI6eyJ0eXBlIjoib2JqZWN0IiwicHJvcGVydGllcyI6eyJwZXJtaXRfbnVtYmVyIjp7InR5cGUiOiJzdHJpbmcifSwicmVnaXN0cmF0aW9uX293bmVyc2hpcCI6eyJ0eXBlIjoic3RyaW5nIiwiZW51bSI6WyJPV05FUiIsIlBST1BFUlRZX01BTkFHRVIiXX0sImVtYWlsIjp7InR5cGUiOiJzdHJpbmcifSwiZnVsbF9uYW1lIjp7InR5cGUiOiJzdHJpbmcifSwiaWRlbnRpZmljYXRpb25fbnVtYmVyIjp7InR5cGUiOiJzdHJpbmcifX0sInJlcXVpcmVkIjpbInBlcm1pdF9udW1iZXIiLCJyZWdpc3RyYXRpb25fb3duZXJzaGlwIiwiZW1haWwiLCJmdWxsX25hbWUiLCJpZGVudGlmaWNhdGlvbl9udW1iZXIiXX0sImV4ZW1wdGlvbiI6eyJ0eXBlIjoib2JqZWN0IiwicHJvcGVydGllcyI6eyJyZWFzb24iOnsidHlwZSI6InN0cmluZyIsImVudW0iOlsiTElTVElOR19UWVBFX05PVF9JTkNMVURFRCIsIkxJU1RJTkdfTk9UX1RPVVJJU1RfQUNDT01NT0RBVElPTiJdfSwicmVnaXN0cmF0aW9uX293bmVyc2hpcCI6eyJ0eXBlIjoic3RyaW5nIiwiZW51bSI6WyJPV05FUiIsIlBST1BFUlRZX01BTkFHRVIiXX0sImVtYWlsIjp7InR5cGUiOiJzdHJpbmcifSwiZnVsbF9uYW1lIjp7InR5cGUiOiJzdHJpbmcifSwiaWRlbnRpZmljYXRpb25fbnVtYmVyIjp7InR5cGUiOiJzdHJpbmcifX0sInJlcXVpcmVkIjpbInJlYXNvbiIsInJlZ2lzdHJhdGlvbl9vd25lcnNoaXAiLCJlbWFpbCIsImZ1bGxfbmFtZSIsImlkZW50aWZpY2F0aW9uX251bWJlciJdfX0sInJlcXVpcmVkIjpbImxpc3RpbmdfaWQiLCJyZWd1bGF0b3J5X2JvZHkiXX0seyJ0aXRsZSI6IkJhbHRpbW9yZSIsInR5cGUiOiJvYmplY3QiLCJwcm9wZXJ0aWVzIjp7Imxpc3RpbmdfaWQiOnsidHlwZSI6ImludGVnZXIifSwicmVndWxhdG9yeV9ib2R5Ijp7InR5cGUiOiJzdHJpbmcifSwicmVnaXN0cmF0aW9uIjp7InR5cGUiOiJvYmplY3QiLCJwcm9wZXJ0aWVzIjp7InBlcm1pdF9udW1iZXIiOnsidHlwZSI6InN0cmluZyJ9LCJleHBpcmF0aW9uX2RhdGUiOnsidHlwZSI6InN0cmluZyJ9LCJmdWxsX25hbWUiOnsidHlwZSI6InN0cmluZyJ9LCJlbWFpbCI6eyJ0eXBlIjoic3RyaW5nIn0sImxpc3RpbmdfYWRkcmVzcyI6eyJ0eXBlIjoic3RyaW5nIn0sImF0dGVzdGF0aW9uX2V4aXN0aW5nX3JlZ2lzdHJhdGlvbiI6eyJ0eXBlIjoiYm9vbGVhbiJ9fSwicmVxdWlyZWQiOlsicGVybWl0X251bWJlciIsImV4cGlyYXRpb25fZGF0ZSIsImZ1bGxfbmFtZSIsImVtYWlsIiwibGlzdGluZ19hZGRyZXNzIiwiYXR0ZXN0YXRpb25fZXhpc3RpbmdfcmVnaXN0cmF0aW9uIl19LCJleGVtcHRpb24iOnsidHlwZSI6Im9iamVjdCIsInByb3BlcnRpZXMiOnsiZXhlbXB0aW9uX3JlYXNvbiI6eyJ0eXBlIjoic3RyaW5nIiwiZW51bSI6WyJob3RlbF9tb3RlbCJdfSwiZnVsbF9uYW1lIjp7InR5cGUiOiJzdHJpbmcifSwiZW1haWwiOnsidHlwZSI6InN0cmluZyJ9LCJhdHRlc3RhdGlvbl9leGVtcHRpb25fY2xhaW0iOnsidHlwZSI6ImJvb2xlYW4ifX0sInJlcXVpcmVkIjpbImV4ZW1wdGlvbl9yZWFzb24iLCJmdWxsX25hbWUiLCJlbWFpbCIsImF0dGVzdGF0aW9uX2V4ZW1wdGlvbl9jbGFpbSJdfX0sInJlcXVpcmVkIjpbImxpc3RpbmdfaWQiLCJyZWd1bGF0b3J5X2JvZHkiXX0seyJ0aXRsZSI6IkJvc3RvbiIsInR5cGUiOiJvYmplY3QiLCJwcm9wZXJ0aWVzIjp7Imxpc3RpbmdfaWQiOnsidHlwZSI6ImludGVnZXIifSwicmVndWxhdG9yeV9ib2R5Ijp7InR5cGUiOiJzdHJpbmcifSwicmVnaXN0cmF0aW9uIjp7InR5cGUiOiJvYmplY3QiLCJwcm9wZXJ0aWVzIjp7InBlcm1pdF9udW1iZXIiOnsidHlwZSI6InN0cmluZyJ9LCJlbWFpbCI6eyJ0eXBlIjoic3RyaW5nIn0sImZ1bGxfbmFtZSI6eyJ0eXBlIjoic3RyaW5nIn0sImxpc3RpbmdfYWRkcmVzcyI6eyJ0eXBlIjoic3RyaW5nIn0sImF0dGVzdGF0aW9uIjp7InR5cGUiOiJib29sZWFuIn19LCJyZXF1aXJlZCI6WyJwZXJtaXRfbnVtYmVyIiwiZW1haWwiLCJmdWxsX25hbWUiLCJsaXN0aW5nX2FkZHJlc3MiLCJhdHRlc3RhdGlvbiJdfSwiZXhlbXB0aW9uIjp7InR5cGUiOiJvYmplY3QiLCJwcm9wZXJ0aWVzIjp7ImV4ZW1wdGlvbl9yZWFzb24iOnsidHlwZSI6InN0cmluZyIsImVudW0iOlsiaG90ZWxfbW90ZWwiLCJiZWRfYnJlYWtmYXN0X2xvZGdpbmciLCJpbnN0aXR1dGlvbmFsX2J1c2luZXNzIiwiaG9zcGl0YWxzIl19LCJsaXN0aW5nX2FkZHJlc3MiOnsidHlwZSI6InN0cmluZyJ9LCJhdHRlc3RhdGlvbiI6eyJ0eXBlIjoiYm9vbGVhbiJ9fSwicmVxdWlyZWQiOlsiZXhlbXB0aW9uX3JlYXNvbiIsImxpc3RpbmdfYWRkcmVzcyIsImF0dGVzdGF0aW9uIl19fSwicmVxdWlyZWQiOlsibGlzdGluZ19pZCIsInJlZ3VsYXRvcnlfYm9keSJdfSx7InRpdGxlIjoiQ2F0YWxvbmlhIiwidHlwZSI6Im9iamVjdCIsInByb3BlcnRpZXMiOnsibGlzdGluZ19pZCI6eyJ0eXBlIjoiaW50ZWdlciJ9LCJyZWd1bGF0b3J5X2JvZHkiOnsidHlwZSI6InN0cmluZyJ9LCJyZWdpc3RyYXRpb24iOnsidHlwZSI6Im9iamVjdCIsInByb3BlcnRpZXMiOnsicGVybWl0X251bWJlciI6eyJ0eXBlIjoic3RyaW5nIn0sInJlZ2lzdHJhdGlvbl9vd25lcnNoaXAiOnsidHlwZSI6InN0cmluZyJ9LCJlbWFpbCI6eyJ0eXBlIjoic3RyaW5nIn0sImZ1bGxfbmFtZSI6eyJ0eXBlIjoic3RyaW5nIn0sImlkZW50aWZpY2F0aW9uX251bWJlciI6eyJ0eXBlIjoic3RyaW5nIn19LCJyZXF1aXJlZCI6WyJwZXJtaXRfbnVtYmVyIiwicmVnaXN0cmF0aW9uX293bmVyc2hpcCIsImVtYWlsIiwiZnVsbF9uYW1lIiwiaWRlbnRpZmljYXRpb25fbnVtYmVyIl19LCJleGVtcHRpb24iOnsidHlwZSI6Im9iamVjdCIsInByb3BlcnRpZXMiOnsicmVhc29uIjp7InR5cGUiOiJzdHJpbmciLCJlbnVtIjpbImxpc3Rpbmdfbm90X2Z1bGxfYnVpbGRpbmciLCJsaXN0aW5nX2lzX3NoYXJlZF9yb29tIiwib3RoZXJfZXhlbXB0aW9uX3JlYXNvbiJdfSwicmVnaXN0cmF0aW9uX293bmVyc2hpcCI6eyJ0eXBlIjoic3RyaW5nIiwiZW51bSI6WyJPV05FUiIsIlBST1BFUlRZX01BTkFHRVIiXX0sImVtYWlsIjp7InR5cGUiOiJzdHJpbmcifSwiZnVsbF9uYW1lIjp7InR5cGUiOiJzdHJpbmcifSwiaWRlbnRpZmljYXRpb25fbnVtYmVyIjp7InR5cGUiOiJzdHJpbmcifX0sInJlcXVpcmVkIjpbInJlYXNvbiIsInJlZ2lzdHJhdGlvbl9vd25lcnNoaXAiLCJlbWFpbCIsImZ1bGxfbmFtZSIsImlkZW50aWZpY2F0aW9uX251bWJlciJdfX0sInJlcXVpcmVkIjpbImxpc3RpbmdfaWQiLCJyZWd1bGF0b3J5X2JvZHkiXX0seyJ0aXRsZSI6IkNoaWNhZ28iLCJ0eXBlIjoib2JqZWN0IiwicHJvcGVydGllcyI6eyJsaXN0aW5nX2lkIjp7InR5cGUiOiJpbnRlZ2VyIn0sInJlZ3VsYXRvcnlfYm9keSI6eyJ0eXBlIjoic3RyaW5nIn0sInJlZ2lzdHJhdGlvbiI6eyJ0eXBlIjoib2JqZWN0IiwicHJvcGVydGllcyI6eyJwZXJtaXRfbnVtYmVyIjp7InR5cGUiOiJzdHJpbmcifX0sInJlcXVpcmVkIjpbInBlcm1pdF9udW1iZXIiXX19LCJyZXF1aXJlZCI6WyJsaXN0aW5nX2lkIiwicmVndWxhdG9yeV9ib2R5IiwicmVnaXN0cmF0aW9uIl19LHsidGl0bGUiOiJDdWJhIiwidHlwZSI6Im9iamVjdCIsInByb3BlcnRpZXMiOnsibGlzdGluZ19pZCI6eyJ0eXBlIjoiaW50ZWdlciJ9LCJyZWd1bGF0b3J5X2JvZHkiOnsidHlwZSI6InN0cmluZyJ9LCJhZmZpbGlhdGlvbiI6eyJ0eXBlIjoib2JqZWN0IiwicHJvcGVydGllcyI6eyJhdHRlc3RhdGlvbl9lbnRyZXByZW5ldXIiOnsidHlwZSI6ImJvb2xlYW4ifSwibGlzdGluZ19hZGRyZXNzIjp7InR5cGUiOiJzdHJpbmcifX0sInJlcXVpcmVkIjpbImF0dGVzdGF0aW9uX2VudHJlcHJlbmV1ciIsImxpc3RpbmdfYWRkcmVzcyJdfX0sInJlcXVpcmVkIjpbImxpc3RpbmdfaWQiLCJyZWd1bGF0b3J5X2JvZHkiLCJhZmZpbGlhdGlvbiJdfSx7InRpdGxlIjoiRGVubWFyayIsInR5cGUiOiJvYmplY3QiLCJwcm9wZXJ0aWVzIjp7Imxpc3RpbmdfaWQiOnsidHlwZSI6ImludGVnZXIifSwicmVndWxhdG9yeV9ib2R5Ijp7InR5cGUiOiJzdHJpbmcifSwiY2F0ZWdvcml6YXRpb24iOnsidHlwZSI6Im9iamVjdCIsInByb3BlcnRpZXMiOnsibGlzdGluZ190eXBlIjp7InR5cGUiOiJzdHJpbmciLCJlbnVtIjpbInByaW1hcnlfcmVzaWRlbmNlIiwiaG91c2Vib2F0IiwidGVudCIsInRyZWVfaG91c2UiLCJob3RlbF9vcl9ob3N0ZWwiLCJzZXJ2aWNlZF9hcGFydG1lbnQiLCJ0cmFpbGVyIiwibW9iaWxlX2hvbWUiLCJzdW1tZXJfaG91c2UiXX0sImRhdGFfcmVwb3J0aW5nX3N0YXR1cyI6eyJ0eXBlIjoic3RyaW5nIiwiZW51bSI6WyJwcml2YXRlX2FjdGl2aXR5IiwiYnVzaW5lc3NfYWN0aXZpdHkiXX0sImRhdGFfcmVwb3J0aW5nX2JiciI6eyJ0eXBlIjoic3RyaW5nIn0sImF0dGVzdGF0aW9uIjp7InR5cGUiOiJib29sZWFuIn0sImF0dGVzdGF0aW9uX2NvbmRpdGlvbmFsIjp7InR5cGUiOiJib29sZWFuIn19LCJyZXF1aXJlZCI6WyJsaXN0aW5nX3R5cGUiXX19LCJyZXF1aXJlZCI6WyJsaXN0aW5nX2lkIiwicmVndWxhdG9yeV9ib2R5IiwiY2F0ZWdvcml6YXRpb24iXX1dfSwidWlTY2hlbWEiOnt9LCJ0aGVtZSI6ImRlZmF1bHQiLCJsaXZlU2V0dGluZ3MiOnsidmFsaWRhdGUiOmZhbHNlLCJkaXNhYmxlIjpmYWxzZSwib21pdEV4dHJhRGF0YSI6ZmFsc2UsImxpdmVPbWl0IjpmYWxzZX19)

Since this `componentDidUpdate` code here is handling cases where the `oneOf` or `anyOf` might have types that differ, and changing the `selectedOption` state to match that, this isn't really valid for our case of integrating this form into our API Explorer as we don't care as much about the actual type behind the data, just that the data can be serialized into a browser API request or code sample.

This fixes the issue we have with AirBnb here: https://app.asana.com/0/1177947654981875/1176610044848938/f